### PR TITLE
Update README.md to point Github to change-history

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ HOWTO: Open source your company's policies
 
 4. Let everyone know by tweeting your repository with the hashtag [#opensourceprivacy](https://twitter.com/search?q=opensourceprivacy&src=typd) and request addition to [PrivacyByChoice](http://privacybychoice.github.io/) page.
 
-As of June 2022, we NO longer updating this repo to reflect changes made to the Clever Privacy Policy. Instead, we are maintaining the change log history via this [page](https://clever.com/trust/privacy/change-history), and the respective privacy-change-history HTML file in the **website** repo will be the sole source of truth for changes.
+As of June 2022, we are no longer updating this repo to reflect changes made to the Clever Privacy Policy. Instead, we are maintaining the change log history via this [page](https://clever.com/trust/privacy/change-history).

--- a/README.md
+++ b/README.md
@@ -14,3 +14,5 @@ HOWTO: Open source your company's policies
 3. Use [Git branches](https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/) and [Pull Requests](https://help.github.com/articles/using-pull-requests/) to manage changes in your policies.
 
 4. Let everyone know by tweeting your repository with the hashtag [#opensourceprivacy](https://twitter.com/search?q=opensourceprivacy&src=typd) and request addition to [PrivacyByChoice](http://privacybychoice.github.io/) page.
+
+As of June 2022, we NO longer updating this repo to reflect changes made to the Clever Privacy Policy. Instead, we are maintaining the change log history via this [page](https://clever.com/trust/privacy/change-history), and the respective privacy-change-history HTML file in the **website** repo will be the sole source of truth for changes.


### PR DESCRIPTION
[DEIP-1022](https://clever.atlassian.net/browse/DEIP-1022)

This PR updates the policy repo to say that we no longer make privacy policy updates in that repo. Instead users are directed to [https://clever.com/trust/privacy/change-history](https://clever.com/trust/privacy/change-history).